### PR TITLE
Github CI provider for new projects

### DIFF
--- a/internal/v1/cmd/new.go
+++ b/internal/v1/cmd/new.go
@@ -246,7 +246,7 @@ func init() {
 	newCmd.Flags().Bool("skip-yarn", false, "use npm instead of yarn for frontend dependencies management")
 	newCmd.Flags().String("db-type", "postgres", fmt.Sprintf("specify the type of database you want to use [%s]", strings.Join(pop.AvailableDialects, ", ")))
 	newCmd.Flags().String("docker", "multi", "specify the type of Docker file to generate [none, multi, standard]")
-	newCmd.Flags().String("ci-provider", "none", "specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci]")
+	newCmd.Flags().String("ci-provider", "none", "specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci, github-ci]")
 	newCmd.Flags().String("vcs", "git", "specify the Version control system you would like to use [none, git, bzr]")
 	newCmd.Flags().String("module", "", "specify the root module (package) name. [defaults to 'automatic']")
 	viper.BindPFlags(newCmd.Flags())

--- a/internal/v1/genny/ci/ci.go
+++ b/internal/v1/genny/ci/ci.go
@@ -3,6 +3,7 @@ package ci
 import (
 	"fmt"
 	"html/template"
+	"path"
 
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/genny/gogen"
@@ -20,6 +21,10 @@ func New(opts *Options) (*genny.Generator, error) {
 	g.Transformer(genny.Replace("-no-pop", ""))
 	g.Transformer(genny.Dot())
 
+	if opts.Provider == "github" || opts.Provider == "github-ci" {
+		g.Transformer(genny.Replace("github-ci.yml", path.Join(".github", "workflows", "tests.yml")))
+	}
+
 	box := packr.New("buffalo:genny:ci", "../ci/templates")
 
 	var fname string
@@ -32,6 +37,8 @@ func New(opts *Options) (*genny.Generator, error) {
 		} else {
 			fname = "-dot-gitlab-ci-no-pop.yml.tmpl"
 		}
+	case "github", "github-ci":
+		fname = "github-ci.yml.tmpl"
 	default:
 		return g, fmt.Errorf("could not find a template for %s", opts.Provider)
 	}

--- a/internal/v1/genny/ci/ci_test.go
+++ b/internal/v1/genny/ci/ci_test.go
@@ -95,3 +95,31 @@ func Test_New_Gitlab_No_pop(t *testing.T) {
 	r.Equal(".gitlab-ci.yml", f.Name())
 	r.NotContains(f.String(), "postgres:5432")
 }
+
+func Test_New_Github(t *testing.T) {
+	r := require.New(t)
+
+	app := meta.New(".")
+	app.WithPop = true
+
+	g, err := New(&Options{
+		App:      app,
+		Provider: "github",
+		DBType:   "postgres",
+	})
+	r.NoError(err)
+
+	run := gentest.NewRunner()
+	run.With(g)
+
+	r.NoError(run.Run())
+
+	res := run.Results()
+
+	r.Len(res.Commands, 0)
+	r.Len(res.Files, 1)
+
+	f := res.Files[0]
+	r.Equal(".github/workflows/tests.yml", f.Name())
+	r.Contains(f.String(), "postgres:5432")
+}

--- a/internal/v1/genny/ci/options.go
+++ b/internal/v1/genny/ci/options.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Available CI implementations
-var Available = []string{"travis", "gitlab"}
+var Available = []string{"travis", "gitlab", "github"}
 
 // Options for CI
 type Options struct {

--- a/internal/v1/genny/ci/templates/github-ci.yml.tmpl
+++ b/internal/v1/genny/ci/templates/github-ci.yml.tmpl
@@ -1,0 +1,47 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  tests:
+    name: ${{ printf "%s %s %s" "{{" "matrix.os" "}}" }} Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        go: [1.13]
+    runs-on: ${{ printf "%s %s %s" "{{" "matrix.os" "}}" }}
+    container: golang:${{ printf "%s %s %s" "{{" "matrix.go" "}}" }}
+{{ if eq .opts.DBType "postgres" }}
+    services:
+      postgres:
+        image: postgres:latest
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+{{- end }}
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Download dependencies
+        run: |
+          go get -u -v github.com/gobuffalo/buffalo-cli/cmd/buffalo
+          go mod download
+          go mod tidy -v
+
+      - name: Run tests
+        env:
+          GO_ENV: test
+{{- if eq .opts.DBType "postgres" }}
+          TEST_DATABASE_URL: {{ .testDbUrl }}
+{{- end }}
+        run: |
+          buffalo test


### PR DESCRIPTION
In addition to Gitlab and Travis, provide Github CI for easy CI testing
on Github projects when creating a new project (flag: --ci-provider)

Fixes #13 