### PR TITLE
Avoid CLI fix if cmd/buffalo exists

### DIFF
--- a/cli/internal/clifix/clifix.go
+++ b/cli/internal/clifix/clifix.go
@@ -2,6 +2,7 @@ package clifix
 
 import "github.com/gobuffalo/plugins"
 
+//Plugins returns the plugins for the clifix.
 func Plugins() []plugins.Plugin {
 	return []plugins.Plugin{
 		&Fixer{},

--- a/cli/internal/clifix/fixer.go
+++ b/cli/internal/clifix/fixer.go
@@ -19,17 +19,22 @@ var _ plugins.Plugin = &Fixer{}
 var _ plugcmd.Namer = &Fixer{}
 var _ fix.Fixer = &Fixer{}
 
+//Fixer creates the cli file at cmd/buffalo/main.go if it doesn't exist.
 type Fixer struct {
 }
 
+//PluginName for this cli fixer
 func (*Fixer) PluginName() string {
 	return "cli/fixer"
 }
 
+//CmdName for this cli fixer
 func (*Fixer) CmdName() string {
 	return "cli"
 }
 
+//Fix will be invoked when buffalo fix is called, it creates cmd/buffalo/main.go
+//with tmplMain if it doesn't exist.
 func (fixer *Fixer) Fix(ctx context.Context, root string, args []string) error {
 	info, err := here.Dir(root)
 	if err != nil {
@@ -43,7 +48,7 @@ func (fixer *Fixer) Fix(ctx context.Context, root string, args []string) error {
 
 	_, err = os.Stat(filepath.Join(x, "main.go"))
 	if err == nil {
-		fmt.Println("cmd/buffalo/main.go already exist, no need to fix it")
+		fmt.Println("cmd/buffalo/main.go already exist,s no need to fix it")
 		return err
 	}
 

--- a/cli/internal/clifix/fixer.go
+++ b/cli/internal/clifix/fixer.go
@@ -41,6 +41,12 @@ func (fixer *Fixer) Fix(ctx context.Context, root string, args []string) error {
 		filepath.Join(x, "main.go"): tmplMain,
 	}
 
+	_, err = os.Stat(filepath.Join(x, "main.go"))
+	if err == nil {
+		fmt.Println("cmd/buffalo/main.go already exist, no need to fix it")
+		return err
+	}
+
 	for fp, body := range mm {
 		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
 			return err

--- a/cli/internal/clifix/fixer.go
+++ b/cli/internal/clifix/fixer.go
@@ -46,9 +46,9 @@ func (fixer *Fixer) Fix(ctx context.Context, root string, args []string) error {
 		filepath.Join(x, "main.go"): tmplMain,
 	}
 
-	_, err = os.Stat(filepath.Join(x, "main.go"))
+	_, err = os.Stat(x)
 	if err == nil {
-		fmt.Println("cmd/buffalo/main.go already exist,s no need to fix it")
+		fmt.Println("cmd/buffalo folder already exists")
 		return err
 	}
 

--- a/cli/internal/clifix/fixer_test.go
+++ b/cli/internal/clifix/fixer_test.go
@@ -48,17 +48,14 @@ func Test_Fixer_FileExists(t *testing.T) {
 
 	f, err := os.Create(filepath.Join(dir, "go.mod"))
 	r.NoError(err)
-	f.WriteString("module coke")
+	f.WriteString("module pagano")
 	r.NoError(f.Close())
 
 	ctx := context.Background()
 	var args []string
 
 	cliFolder := filepath.Join(dir, "cmd", "buffalo")
-	os.MkdirAll(cliFolder, 0755)
-
-	d1 := []byte(tmplMain)
-	err = ioutil.WriteFile(filepath.Join(cliFolder, "main.go"), d1, 0755)
+	err = os.MkdirAll(cliFolder, 0755)
 	r.NoError(err)
 
 	fixer := &Fixer{}

--- a/cli/internal/clifix/fixer_test.go
+++ b/cli/internal/clifix/fixer_test.go
@@ -39,3 +39,29 @@ func Test_Fixer_Fix(t *testing.T) {
 	r.Contains(string(b), `coke/cmd/buffalo`)
 
 }
+
+func Test_Fixer_FileExists(t *testing.T) {
+	r := require.New(t)
+
+	dir, err := ioutil.TempDir("", "")
+	r.NoError(err)
+
+	f, err := os.Create(filepath.Join(dir, "go.mod"))
+	r.NoError(err)
+	f.WriteString("module coke")
+	r.NoError(f.Close())
+
+	ctx := context.Background()
+	var args []string
+
+	cliFolder := filepath.Join(dir, "cmd", "buffalo")
+	os.MkdirAll(cliFolder, 0755)
+
+	d1 := []byte(tmplMain)
+	err = ioutil.WriteFile(filepath.Join(cliFolder, "main.go"), d1, 0755)
+	r.NoError(err)
+
+	fixer := &Fixer{}
+	err = fixer.Fix(ctx, dir, args)
+	r.NoError(err)
+}


### PR DESCRIPTION
This allows fixers to continue executing if the cli fix file already exists.