### PR TITLE
Adds webpack and refresh plugins

### DIFF
--- a/cli/cmds/cmds.go
+++ b/cli/cmds/cmds.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gobuffalo/buffalo-cli/v2/cli/cmds/setup"
 	"github.com/gobuffalo/buffalo-cli/v2/cli/cmds/test"
 	"github.com/gobuffalo/buffalo-cli/v2/cli/cmds/version"
+	"github.com/gobuffalo/buffalo-cli/v2/cli/internal/plugins/refresh"
+	"github.com/gobuffalo/buffalo-cli/v2/cli/internal/plugins/webpack"
 	"github.com/gobuffalo/buffalo-cli/v2/meta"
 	"github.com/gobuffalo/plugins"
 )
@@ -51,5 +53,9 @@ func insidePlugins() []plugins.Plugin {
 	plugs = append(plugs, resource.Plugins()...)
 	plugs = append(plugs, setup.Plugins()...)
 	plugs = append(plugs, test.Plugins()...)
+
+	plugs = append(plugs, webpack.Plugins()...)
+	plugs = append(plugs, refresh.Plugins()...)
+
 	return plugs
 }


### PR DESCRIPTION
After running `buffalo dev` with the buffalo-cli I noticed that dev was not doing anything. I looked a bit deeper and noticed that was because there were no `Developer` plugins installed.

This PR adds `refresh` and `webpack` plugins on the insidePlugins function so these can become available for the `develop` command to use them. I noticed that this is also happening with the `generate resource` command as it's not finding any available command.

@markbates I was not sure this was the correct place to put those, looking for your guidance on this one.